### PR TITLE
Pin boto3 to > 1.26

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,12 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aws-excom"
-version = "0.0.18"
-dependencies = ['simple-term-menu', 'termcolor', 'boto3']
+version = "0.0.19"
+dependencies = [
+    'simple-term-menu',
+    'termcolor',
+    'boto3 >= 1.26',
+]
 authors = [
   { name="Ben Vosper", email="author@example.com" },
 ]


### PR DESCRIPTION
Enables AWS profiles using Identity Center.

Installing in a fresh environment now gives:

```
β pip freeze
aws-excom @ file:///home/benv/code/aws-excom
boto3==1.26.69
botocore==1.29.69
jmespath==1.0.1
python-dateutil==2.8.2
s3transfer==0.6.0
simple-term-menu==1.6.1
six==1.16.0
termcolor==2.2.0
urllib3==1.26.14
```
